### PR TITLE
Auto-resize day numbers in overview

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@
 name: "Test, audit and lint"
 on:
   push:
-    branches: [ "main" ]
+
   pull_request:
     branches: [ "main" ]
+
 jobs:
   rspec:
     runs-on: ubuntu-latest

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -31,3 +31,18 @@
     background-color: #c0c0c0;
     color: $dark;
 }
+
+.calendar-container {
+    container-type: inline-size;
+}
+
+.calendar-content {
+    font-size: 4vw;
+    text-wrap: nowrap;
+}
+
+@container (min-width: 26px) {
+    .calendar-content {
+        font-size: calc(1.3rem + 0.6vw);
+    }
+}

--- a/app/views/years/_days_overview.html.erb
+++ b/app/views/years/_days_overview.html.erb
@@ -5,8 +5,8 @@
       <div class="col">
         <%= link_to year_day_url(@year.number, day.number), class: 'link-underline link-underline-opacity-0' do %>
           <div class="card <%= bg_class_for_day(day) %>">
-            <div class="card-body w-auto text-center align-middle">
-              <span class="fs-3 text-reset"><%= day.number %></span>
+            <div class="card-body w-auto text-center align-middle calendar-container">
+              <span class="text-reset calendar-content"><%= day.number %></span>
             </div>
           </div>
         <% end %>


### PR DESCRIPTION
This should prevent them from wrapping unintentionally, which fixes #21 