### PR TITLE
Change job schedule and deadline for leaderboard sync

### DIFF
--- a/app/jobs/close_all_days_job.rb
+++ b/app/jobs/close_all_days_job.rb
@@ -4,6 +4,7 @@ class CloseAllDaysJob < ApplicationJob
   def perform(kwargs = {})
     ActiveRecord::Base.transaction do
       year = Year.find_by!(number: kwargs[:year])
+      year.update!(finished: true)
       year.days.where(open: true).each do |day|
         day.update!(open: false)
       end

--- a/app/jobs/setup_leaderboard_job.rb
+++ b/app/jobs/setup_leaderboard_job.rb
@@ -1,8 +1,14 @@
 class SetupLeaderboardJob < ApplicationJob
   queue_as :default
 
-  def perform(options = {})
+  def perform(options = {year: Time.now.year, days: 25, min_interval: 20})
     setup = AdventOfCode::Setup.new(options[:year])
     setup.create_models(options[:days])
+
+    # To make sure you could call this retroactively on leaderboards that
+    # have already been set up in the database, this job is extracted from
+    # the main job. Call it separately if you do not want new database
+    # models, just the update jobs.
+    SetupLeaderboardUpdatesJob.perform_now(options)
   end
 end

--- a/app/jobs/setup_leaderboard_updates_job.rb
+++ b/app/jobs/setup_leaderboard_updates_job.rb
@@ -1,0 +1,21 @@
+class SetupLeaderboardUpdatesJob < ApplicationJob
+  def perform(options = {year: Time.now.year, days: 25, min_interval: 20})
+    GoodJob::Bulk.enqueue do
+      # We start running at 5AM UTC on December 1st and end after the given
+      # amount of days. For each minute interval given, we will enqueue a job
+      # to update this leaderboard, as far as those times are in the future.
+      start_time = DateTime.new(options[:year], 12, 1, 5, 0)
+      end_time   = start_time + options[:days].days
+
+      time = start_time
+      while time <= end_time
+        # We do not need to enqueue jobs that are in the past
+        if time > Time.now
+          UpdateLeaderboardJob.set(wait_until: time).perform_later
+        end
+
+        time = time + options[:min_interval].minutes
+      end
+    end
+  end
+end

--- a/app/jobs/update_leaderboard_job.rb
+++ b/app/jobs/update_leaderboard_job.rb
@@ -1,11 +1,23 @@
 class UpdateLeaderboardJob < ApplicationJob
   queue_as :default
 
+  before_perform :check_if_stale_job
+
   def perform(options = {})
     client = AdventOfCode::APIClient.new(
       options[:year], options[:leaderboard_id], options[:cookie]
     )
     parser = AdventOfCode::Parser.new(client.leaderboard)
     parser.import
+  end
+
+  private
+
+  def check_if_stale_job
+    # If the server has been off for some time, we do not want to kill
+    # Advent of Code with a million requests. Therefore, a safety is
+    # built in to only execute these jobs if their time is set to less
+    # than five minutes ago.
+    throw :abort if scheduled_at && scheduled_at < Time.now - 5.minutes
   end
 end

--- a/db/migrate/20231128232542_add_finished_boolean_to_years.rb
+++ b/db/migrate/20231128232542_add_finished_boolean_to_years.rb
@@ -1,0 +1,5 @@
+class AddFinishedBooleanToYears < ActiveRecord::Migration[7.1]
+  def change
+    add_column :years, :finished, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2023_11_22_002713) do
+ActiveRecord::Schema[7.1].define(version: 2023_11_28_232542) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -129,6 +129,9 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_22_002713) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "admin", default: false, null: false
+    t.string "fortytwo_api_token"
+    t.string "fortytwo_api_refresh_token"
+    t.datetime "fortytwo_api_expires_at"
     t.index ["aoc_user_id"], name: "index_users_on_aoc_user_id", unique: true
     t.index ["username"], name: "index_users_on_username", unique: true
   end
@@ -137,6 +140,7 @@ ActiveRecord::Schema[7.1].define(version: 2023_11_22_002713) do
     t.integer "number"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "finished", default: false, null: false
     t.index ["number"], name: "index_years_on_number", unique: true
   end
 


### PR DESCRIPTION
After consulting with staff, I've changed the jobs to only sync the leaderboard until 24 hours after the last puzzle has been posted. After that, the year will be marked as finished. Because this is harder to capture in a cron-style schedule, setting up the leaderboard now involves scheduling all the update jobs instead of having them run on cron. Closes #19 

**Warning!** If you have already run the SetupLeaderboardJob for an upcoming year, that year will now not have any update jobs scheduled, since I have replaced the cron auto-execution with scheduling ahead of time. To remedy this, run a SetupLeaderboardUpdatesJob over the leaderboard, which schedules all the refreshes.