### PR TITLE
Do not show PII to users who are not logged in

### DIFF
--- a/app/models/participant.rb
+++ b/app/models/participant.rb
@@ -6,7 +6,7 @@ class Participant < ApplicationRecord
 
   default_scope { joins(:user) }
 
-  delegate :username, :full_name, :photo_url, :aoc_user_id, to: :user
+  delegate :username, :full_name, :photo_url, :aoc_user_id, :intra_url, to: :user
 
   validates :user, uniqueness: { scope: :year }
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -27,6 +27,10 @@ class User < ApplicationRecord
     )
   end
 
+  def intra_url
+    return "https://profile.intra.42.fr/users/#{username}"
+  end
+
   private
 
   def remove_hashtags

--- a/app/views/days/_gold_leaderboard.html.erb
+++ b/app/views/days/_gold_leaderboard.html.erb
@@ -11,8 +11,7 @@
       <tr>
         <td><strong><%= i + 1 %></strong></td>
         <td>
-            <img src="<%= r[0].photo_url %>" class="inline-avatar rounded">
-            <%= r[0].username %>
+            <%= render r[0] %>
         </td>
         <td><%= r[1].completed_at.to_scoreboard_format %></td>
       </tr>

--- a/app/views/days/_silver_leaderboard.html.erb
+++ b/app/views/days/_silver_leaderboard.html.erb
@@ -11,8 +11,7 @@
       <tr>
         <td><strong><%= i + 1 %></strong></td>
         <td>
-            <img src="<%= r[0].photo_url %>" class="inline-avatar rounded">
-            <%= r[0].username %>
+            <%= render r[0] %>
         </td>
         <td><%= r[1].completed_at.to_scoreboard_format %></td>
       </tr>

--- a/app/views/participants/_full.html.erb
+++ b/app/views/participants/_full.html.erb
@@ -1,0 +1,11 @@
+<% if logged_in? %>
+  <span class="fw-bolder me-1">
+    <img src="<%= participant.photo_url %>" class="inline-avatar rounded">
+    <%= participant.username %>
+  </span>
+  <span class="italic text-secondary">
+    <%= participant.full_name %>
+  </span>
+<% else %>
+  <%= render 'participants/username_only', participant: participant %>
+<% end %>

--- a/app/views/participants/_full.html.erb
+++ b/app/views/participants/_full.html.erb
@@ -1,8 +1,8 @@
 <% if logged_in? %>
-  <span class="fw-bolder me-1">
+  <%= link_to participant.intra_url, class: 'text-reset fw-bolder link-underline link-underline-opacity-0 link-underline-opacity-75-hover me-1', target: '_blank' do %>
     <img src="<%= participant.photo_url %>" class="inline-avatar rounded">
     <%= participant.username %>
-  </span>
+  <% end %>
   <span class="italic text-secondary">
     <%= participant.full_name %>
   </span>

--- a/app/views/participants/_participant.html.erb
+++ b/app/views/participants/_participant.html.erb
@@ -1,0 +1,8 @@
+<% if logged_in? %>
+  <%= link_to participant.intra_url, class: 'text-reset link-underline link-underline-opacity-0 link-underline-opacity-75-hover', target: '_blank' do %>
+    <img src="<%= participant.photo_url %>" class="inline-avatar rounded">
+    <%= participant.username %>
+  <% end %>
+<% else %>
+  <%= render 'participants/username_only', participant: participant %>
+<% end %>

--- a/app/views/participants/_username_only.html.erb
+++ b/app/views/participants/_username_only.html.erb
@@ -1,0 +1,3 @@
+<span class="fw-bolder text-reset">
+  <%= participant.username %>
+</span>

--- a/app/views/years/_scoreboard.html.erb
+++ b/app/views/years/_scoreboard.html.erb
@@ -17,8 +17,7 @@
       <tr>
         <td><strong><%= i + 1 %></strong></td>
         <td>
-            <img src="<%= p.photo_url %>" class="inline-avatar rounded">
-            <%= p.username %>
+            <%= render 'participants/full', participant: p %>
         </td>
         <td><%= p.score %></td>
         <td><%= p.gold_stars.count %></td>

--- a/spec/models/participant_spec.rb
+++ b/spec/models/participant_spec.rb
@@ -13,6 +13,11 @@ RSpec.describe Participant, type: :model do
     )
   end
 
+  it 'should respond to intra_url' do
+    user = create(:user)
+    expect(user).to respond_to(:intra_url)
+  end
+
   describe 'user' do
     it 'should not have to be unique across different years' do
       user          = create(:user)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -80,4 +80,12 @@ RSpec.describe User, type: :model do
       expect { participant.user.destroy }.to change { Participant.count }.by(-1)
     end
   end
+
+  describe 'intra_url' do
+    it 'should return a proper intra URL' do
+      user = create(:user)
+
+      expect(user.intra_url).to eq("https://profile.intra.42.fr/users/#{user.username}")
+    end
+  end
 end


### PR DESCRIPTION
This PR implements participant partials which only show photos and full names to logged in users. To all other visitors, they default to showing a plain username. This closes #20.