### PR TITLE
Add helper specs

### DIFF
--- a/app/helpers/days_helper.rb
+++ b/app/helpers/days_helper.rb
@@ -26,14 +26,17 @@ module DaysHelper
     return num_gold
   end
 
-  def top_speeds(day, n = 5, index = 2)
-    stars = day.stars.joins(:participant).where(index: index)
+  # For when we need the absolute total of silver stars,
+  # rather than the participant count who only have this star.
+  def count_silver_stars(day)
+    return day.stars.where(index: 1).count
+  end
+
+  def top_speeds(day, index = 2, n = 3)
+    stars = day.stars.includes(:participant).where(index: index)
                      .order(completed_at: :asc).limit(n)
 
-    # It is possible that our array includes two stars for the same
-    # participant, so we grab the maximum required number and
-    # filter out duplicate values.
-    return stars.map { |star| [star.participant, star] }
+    return stars
   end
 
   def rank_for_participant(day, participant)
@@ -45,16 +48,6 @@ module DaysHelper
       "Gold + Silver"
     else
       "Silver"
-    end
-  end
-
-  def time_for_participant(day, participant)
-    top_star = day.stars.where(participant: participant).order(index: :desc).first
-
-    if !top_star
-      nil
-    else
-      top_star.completed_at
     end
   end
 

--- a/app/views/days/_day.html.erb
+++ b/app/views/days/_day.html.erb
@@ -13,8 +13,8 @@
 <h5>Today's fastest</h5>
 
 <h6>Gold</h6>
-<% if top_speeds(day, 5, 2).any? %>
-  <%= render 'days/gold_leaderboard', day: day, count: 5 %>
+<% if top_speeds(day, 2).any? %>
+  <%= render 'days/gold_leaderboard', day: day, count: 3 %>
 <% else %>
   <p class="text-secondary text-center">
     You can still be the first to complete today's gold level!
@@ -22,8 +22,8 @@
 <% end %>
 
 <h6>Silver</h6>
-<% if top_speeds(day, 5, 1).any? %>
-  <%= render 'days/silver_leaderboard', day: day, count: 5 %>
+<% if top_speeds(day, 1).any? %>
+  <%= render 'days/silver_leaderboard', day: day, count: 3 %>
 <% else %>
   <p class="text-secondary text-center">
     You can still be the first to complete today's silver level!

--- a/app/views/days/_gold_leaderboard.html.erb
+++ b/app/views/days/_gold_leaderboard.html.erb
@@ -7,13 +7,22 @@
     </tr>
   </thead>
   <tbody>
-    <% top_speeds(day, count, 2).each.with_index do |r, i| %>
+    <% top_speeds(day, 2, count).each.with_index do |star, i| %>
       <tr>
         <td><strong><%= i + 1 %></strong></td>
         <td>
-            <%= render r[0] %>
+            <%= render star.participant %>
         </td>
-        <td><%= time_taken(day, r[1]) %></td>
+        <td><%= time_taken(day, star) %></td>
+      </tr>
+    <% end %>
+    <% if count_gold(day) > count %>
+      <tr>
+        <td colspan="3" class="text-secondary text-center">
+          <%= link_to year_day_url(day.year.number, day.number), class: 'link-secondary' do %>
+            Full leaderboard (+<%= count_gold(day) - count %>)
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/days/_silver_leaderboard.html.erb
+++ b/app/views/days/_silver_leaderboard.html.erb
@@ -7,13 +7,22 @@
     </tr>
   </thead>
   <tbody>
-    <% top_speeds(day, count, 1).each.with_index do |r, i| %>
+    <% top_speeds(day, 1, count).each.with_index do |star, i| %>
       <tr>
         <td><strong><%= i + 1 %></strong></td>
         <td>
-            <%= render r[0] %>
+            <%= render star.participant %>
         </td>
-        <td><%= time_taken(day, r[1]) %></td>
+        <td><%= time_taken(day, star) %></td>
+      </tr>
+    <% end %>
+    <% if count_silver_stars(day) > count %>
+      <tr>
+        <td colspan="3" class="text-secondary text-center">
+          <%= link_to year_day_url(day.year.number, day.number), class: 'link-secondary' do %>
+            Full leaderboard (+<%= count_silver_stars(day) - count %>)
+          <% end %>
+        </td>
       </tr>
     <% end %>
   </tbody>

--- a/spec/helpers/days_helper_spec.rb
+++ b/spec/helpers/days_helper_spec.rb
@@ -1,0 +1,189 @@
+require 'rails_helper'
+
+RSpec.describe DaysHelper, type: :helper do
+  describe 'counts' do
+    before :each do
+      @day = create(:day)
+
+      # Incompletes
+      5.times do
+        create(:participant, year: @day.year)
+      end
+
+      # Silvers
+      3.times do
+        participant = create(:participant, year: @day.year)
+        create(:star, index: 1, participant: participant, day: @day)
+      end
+
+      # Golds
+      2.times do
+        participant = create(:participant, year: @day.year)
+        create(:star, index: 1, participant: participant, day: @day)
+        create(:star, index: 2, participant: participant, day: @day)
+      end
+    end
+
+    describe 'count_incomplete' do
+      it 'should count all participants that have not completed the day' do
+        expect(count_incomplete(@day)).to eq(5)
+      end
+
+      it 'should add one when an incomplete participant is added' do
+        expect { create(:participant, year: @day.year) }
+              .to change { count_incomplete(@day) }.by(1)
+      end
+
+      it 'should not change when a silver user is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, day: @day, index: 1, participant: participant)
+        }.not_to change { count_incomplete(@day) }
+      end
+
+      it 'should not change when a gold user is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, index: 1, participant: participant, day: @day)
+          create(:star, index: 2, participant: participant, day: @day)
+        }.not_to change { count_incomplete(@day) }
+      end
+    end
+
+    describe 'count_silver' do
+      it 'should count all participants with at least one star' do
+        expect(count_silver(@day)).to eq(3)
+      end
+
+      it 'should add one when a new user with one star is added' do
+        expect { create(:star, day: @day, index: 1) }
+              .to change { count_silver(@day) }.by(1)
+      end
+
+      it 'should not change when an incomplete user is added' do
+        expect { create(:participant, year: @day.year) }
+              .not_to change { count_silver(@day) }
+      end
+
+      it 'should not change when a gold user is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, index: 1, participant: participant, day: @day)
+          create(:star, index: 2, participant: participant, day: @day)
+        }.not_to change { count_silver(@day) }
+      end
+    end
+
+    describe 'count_gold' do
+      it 'should count all participants with two stars' do
+        expect(count_gold(@day)).to eq(2)
+      end
+
+      it 'should add one when a user with two stars is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, index: 1, participant: participant, day: @day)
+          create(:star, index: 2, participant: participant, day: @day)
+        }.to change { count_gold(@day) }.by(1)
+      end
+
+      it 'should not change when a silver user is added' do
+        expect { create(:star, day: @day, index: 1) }
+              .not_to change { count_gold(@day) }
+      end
+
+      it 'should not change when an incomplete user is added' do
+        expect { create(:participant, year: @day.year) }
+              .not_to change { count_gold(@day) }
+      end
+    end
+
+    describe 'count_silver_stars' do
+      it 'should count all silver stars' do
+        expect(count_silver_stars(@day)).to eq(5)
+      end
+
+      it 'should increase when a silver user is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, day: @day, index: 1, participant: participant)
+        }.to change { count_silver_stars(@day) }.by(1)
+      end
+
+      it 'should increase when a gold user is added' do
+        expect {
+          participant = create(:participant, year: @day.year)
+          create(:star, index: 1, participant: participant, day: @day)
+          create(:star, index: 2, participant: participant, day: @day)
+        }.to change { count_silver_stars(@day) }.by(1)
+      end
+
+      it 'should not change when an incomplete user is added' do
+        expect { create(:participant, year: @day.year) }
+              .not_to change { count_silver_stars(@day) }
+      end
+    end
+  end
+
+  describe 'top_speeds' do
+    before :each do
+      @day = create(:day)
+
+      time = Time.utc(2023, 12, 1, 10)
+      10.times do
+        create(:star, completed_at: time, index: 1, day: @day)
+        time = time + 1.hour
+      end
+
+      10.times do
+        create(:star, completed_at: time, index: 2, day: @day)
+        time = time + 1.hour
+      end
+    end
+
+    it 'should only return stars for the given day' do
+      wrong_star = create(:star, day: create(:day, year: @day.year, number: 2), index: 2)
+
+      expect(top_speeds(@day, 2, 20)).not_to include(wrong_star)
+    end
+
+    it 'should return 3 stars by default' do
+      expect(top_speeds(@day, 2).length).to eq(3)
+    end
+
+    it 'should return gold stars by default' do
+      expect(top_speeds(@day).all? { |s| s.index == 2 }).to eq(true)
+    end
+
+    it 'should return the fastest stars' do
+      expect(
+        top_speeds(@day, 1, 5).last.completed_at < Time.utc(2023, 12, 1, 17)
+      ).to eq(true)
+    end
+  end
+
+  describe 'time_taken' do
+    before :each do
+      @year = create(:year, number: 2023)
+      @day  = create(:day, number: 1, year: @year)
+    end
+
+    it 'should return formatted time from 5AM UTC' do
+      star = create(
+        :star,
+        day:          @day,
+        completed_at: Time.utc(2023, 12, 1, 7, 49, 24)
+      )
+      expect(time_taken(@day, star)).to eq('2h, 49m, 24s')
+    end
+
+    it 'should return a fixed string when the difference is over 24 hours' do
+      star = create(
+        :star,
+        day:          @day,
+        completed_at: Time.utc(2023, 12, 4)
+      )
+      expect(time_taken(@day, star)).to eq('>24 hrs')
+    end
+  end
+end

--- a/spec/helpers/years_helper_spec.rb
+++ b/spec/helpers/years_helper_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe YearsHelper, type: :helper do
+  describe 'count_completed_days' do
+    before :each do
+      @year = create(:year, number: 2023)
+
+      i = 1
+      5.times do
+        create(:day, year: @year, number: i)
+        i = i + 1
+      end
+
+      6.times do
+        day = create(:day, year: @year, number: i)
+        create(:star, day: day, index: 1)
+        i = i + 1
+      end
+
+      4.times do
+        day = create(:day, year: @year, number: i)
+        create(:star, day: day, index: 1)
+        create(:star, day: day, index: 2)
+        i = i + 1
+      end
+    end
+
+    it 'should count all days with a star' do
+      expect(count_completed_days(@year)).to eq(10)
+    end
+
+    it 'should change when a new star is obtained' do
+      expect { create(:star, day: @year.days.find_by(number: 1), index: 1) }
+              .to change { count_completed_days(@year) }.by(1)
+    end
+
+    it 'should not count the same day twice' do
+      expect { create(:star, day: @year.days.find_by(number: 7), index: 1) }
+              .not_to change { count_completed_days(@year) }
+    end
+  end
+end


### PR DESCRIPTION
This PR adds unit tests for the helpers in `app/helpers`, as far as they can be tested. This expands the test suite coverage a bit. Currently untested areas of the app are mostly frontend-related, though also the jobs could do with a bit more testing. This PR closes #26.