### PR TITLE
Change time zone to UTC

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module AdventLeaderboard
     # These settings can be overridden in specific environments using the files
     # in config/environments, which are processed later.
     #
-    config.time_zone = "Europe/Amsterdam"
+    config.time_zone = "Etc/UTC"
     # config.eager_load_paths << Rails.root.join("extras")
 
     # Don't generate system test files.


### PR DESCRIPTION
You learn something every day. Fugit apparently assumes our crontabs are meant to run in the time zone we set in `application.rb`, which is why days were getting closed/opened an hour earlier than they were supposed to. The server is now always in UTC, and since all timestamps we show are relative, this should not give us any trouble on the frontend side of things.